### PR TITLE
Replace all instances of ifconfig.me with ifconfig.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var extIP = require('external-ip');
 
 var getIP = extIP({
     replace: true,
-    services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+    services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
     timeout: 600,
     getIP: 'parallel'
 });
@@ -86,7 +86,7 @@ This program prints the external IP of the machine.
 All arguments are optional.
 Examples:
 $ external-ip
-$ external-ip -P -t 1500 -R -s http://icanhazip.com/ -s http://ifconfig.me/ip
+$ external-ip -P -t 1500 -R -s http://icanhazip.com/ -s http://ifconfig.io/ip
 ```
 ##Test
 Change your working directory to the project's root, `npm install` to get the development dependencies and then run `npm test`

--- a/examples/customConfig.js
+++ b/examples/customConfig.js
@@ -4,7 +4,7 @@ var extIP = require('../index');
 
 var getIP = extIP({
     replace: true, // true: replace the default services list, false: extend it, default: false
-    services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+    services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
     timeout: 600, // set timeout per request, default: 500ms
     'getIP': 'parallel'
 });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,7 +21,7 @@ program.on('--help', function () {
         'All arguments are optional.');
     console.log('Examples:');
     console.log('$ external-ip');
-    console.log('$ external-ip -P -t 1500 -R -s http://icanhazip.com/ -s http://ifconfig.me/ip');
+    console.log('$ external-ip -P -t 1500 -R -s http://icanhazip.com/ -s http://ifconfig.io/ip');
 });
 
 program.parse(process.argv);

--- a/lib/extIP.js
+++ b/lib/extIP.js
@@ -20,7 +20,7 @@ module.exports = function (extConf) {
         services: [
             'http://ifconfig.co/x-real-ip',
             'http://icanhazip.com/',
-            'http://ifconfig.me/ip',
+            'http://ifconfig.io/ip',
             'http://ip.appspot.com/',
             'http://curlmyip.com/',
             'http://ident.me/',

--- a/test/test.index.js
+++ b/test/test.index.js
@@ -24,7 +24,7 @@ describe('index.js test', function () {
 
         var getIP = extIP({
             replace: true, // true: replace the default services list, false: extend it, default: false
-            services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+            services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
             timeout: 600, // set timeout per request, default: 500ms,
             getIP: 'parallel'
         });

--- a/test/test.requests.js
+++ b/test/test.requests.js
@@ -4,7 +4,7 @@
 var expect = require('chai').expect;
 var requests = require('../lib/requests').setup({
     replace: false,
-    services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+    services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
     timeout: 500
 });
 

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -28,12 +28,12 @@ describe('utils.js test', function () {
         var config = {
             a: {
                 replace: false,
-                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
                 timeout: 500,
                 gerIP: 'sequential'
             },
             b: {
-                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
                 timeout: 500,
                 getIP: 'parallel'
             },
@@ -78,13 +78,13 @@ describe('utils.js test', function () {
         var config = {
             default: {
                 replace: false,
-                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
                 timeout: 500,
                 getIP: 'sequential'
             },
             a: {},
             b: {
-                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.me/ip'],
+                services: ['http://ifconfig.co/x-real-ip', 'http://ifconfig.io/ip'],
                 timeout: 1000,
                 getIP: 'parallel'
             },


### PR DESCRIPTION
ifconfig.me should be removed as a default and example server. Querying ifconfig.me takes from 1-20 seconds. In many instances it times out completely.

It as been this way for over a year now, and getting progressively worse.

This PR replaces with one that I have tested to handle over 10,000rps as it is a no frills service. It doesn't even log, because why would it.